### PR TITLE
Un-hiding dev flag from help - it disables the option completely, com…

### DIFF
--- a/src/core/CommandRegistrationService.js
+++ b/src/core/CommandRegistrationService.js
@@ -57,7 +57,7 @@ module.exports = class CommandRegistrationService {
 			option1.name.localeCompare(option2.name)
 		);
 		optionsSortedByName.forEach(option => {
-			if (option.disableInIntegrationMode || option.hidden) {
+			if (option.disableInIntegrationMode) {
 				return;
 			}
 			let mandatoryOptionString = '';

--- a/src/metadata/NodeCommandsMetadata.json
+++ b/src/metadata/NodeCommandsMetadata.json
@@ -11,8 +11,7 @@
                 "alias": "d",
                 "description": "Specify the domain URL of the account you want to use. You only need to specify the domain URL if you are not using a production account.",
                 "type": "FLAG",
-                "mandatory": false,
-                "hidden": true
+                "mandatory": false
             }
         ]
     },


### PR DESCRIPTION
…mander.js doesn't support hiding options from help